### PR TITLE
[frontend] fix: island 로컬스토리지에 날짜 추가 오류 수정

### DIFF
--- a/frontend/src/core/usecases/emotionUseCases.ts
+++ b/frontend/src/core/usecases/emotionUseCases.ts
@@ -124,7 +124,7 @@ export class EmotionUseCases {
     return data?.entries?.[stage]?.answer || null;
   }
 
-  // 감정 분석 및 저장
+  // 감정 분석 및 저장 - 삭제
   async analyzeAndSaveEmotion(date: string): Promise<AnalysisResult> {
     const data = await this.emotionStorage.getByDate(date);
 
@@ -146,6 +146,11 @@ export class EmotionUseCases {
     }
 
     return result;
+  }
+
+  async updateCategoryAndEmotion(date: string, category: Category, emotion: EmotionType): Promise<void> {
+    await this.emotionStorage.updateCategoryAndEmotion(date, category, emotion);
+    await this.islandUseCases.addDateToCategory(category, date);
   }
 
   // AI 피드백 저장

--- a/frontend/src/ui/hooks/useEmotion.ts
+++ b/frontend/src/ui/hooks/useEmotion.ts
@@ -269,7 +269,8 @@ export const useEmotion = () => {
       setIsLoading(true);
       setError(null);
       const today = getCurrentDate();
-      await emotionStorage.updateCategoryAndEmotion(today, category, emotion);
+      // core의 usecase 단으로 변경 (island 로컬스토리지 addDateToCategory 추가된 상태)
+      await emotionUseCases.updateCategoryAndEmotion(today, category, emotion);
       const data = await emotionStorage.getByDate(today);
       console.log("data emotion:"+ data?.emotion);
       console.log("data aiFeedback" + data?.aiFeedback);
@@ -281,7 +282,7 @@ export const useEmotion = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [emotionStorage]);
+  }, [emotionUseCases, emotionStorage]);
 
   const saveAIFeedback = useCallback(
     async (date: string, feedback: string) => {


### PR DESCRIPTION
## 작업사항
- island 로컬스토리지에 날짜 추가(addDateToCategory) 오류 수정
cf.
updateCategoryAndEmotion라는 것을 service에서 구체화(진짜 카테고리 이모션만 업데이트 되는 버전) -> 다른 core단의 usecase(addDateToCategory)와 합친 버전이 core usecase에 updateCategoryAndEmotion로 만들어짐