### PR TITLE
Yeonsoo/frontend/island feature4

### DIFF
--- a/frontend/src/app/_components/icons/Letter/index.tsx
+++ b/frontend/src/app/_components/icons/Letter/index.tsx
@@ -54,10 +54,10 @@ export default function LetterClosed({
   emotion?: "joy" | "peace" | "sadness" | "anger" | "anxiety";
 }) {
   const emotionColors: Record<string, string> = {
-    joy: "#B0B062",
+    joy: "#FEE191",
     peace: "#62B067",
     sadness: "#4F69D2",
-    anger: "#BC4547",
+    anger: "rgba(218, 47, 47, 0.8)",
     anxiety: "#AB1EB7",
   };
 
@@ -67,7 +67,7 @@ export default function LetterClosed({
   variant === "dashed"
     ? "#CBA988"
     : variant === "colored"
-    ? "rgba(203, 169, 136, 0.8)"
+    ? "rgba(163, 132, 101, 0.8)"
     : "#CBA988";
   const strokeDasharray = variant === "dashed" ? "4 2" : "none";
 
@@ -85,7 +85,9 @@ export default function LetterClosed({
       {variant === "colored" && (
         <defs>
           <radialGradient id={gradientId} cx="50%" cy="50%" r="100%">
-            <stop offset="0%" stopColor={gradientColor} stopOpacity="0.7" />
+            <stop offset="0%" stopColor={gradientColor} stopOpacity="0.5" />
+            <stop offset="70%" stopColor={gradientColor} stopOpacity="0.4" />
+            <stop offset="90%" stopColor={gradientColor} stopOpacity="0.2" />
             <stop offset="100%" stopColor={gradientColor} stopOpacity="0" />
           </radialGradient>
         </defs>

--- a/frontend/src/app/_components/island/InitDummyData.tsx
+++ b/frontend/src/app/_components/island/InitDummyData.tsx
@@ -3,12 +3,11 @@
 import { useEffect } from "react";
 import { EmotionStorage } from "@/services/storage/emotionStorage";
 import { LetterStorage } from "@/services/storage/letterStorage";
+import { Category, EmotionType } from "@/core/entities/emotion"
 import dummyData from "./dummyData.json"; 
 
 const emotionStorage = new EmotionStorage();
 const letterStorage = new LetterStorage();
-type Category = 'self' | 'growth' | 'routine' | 'relationship';
-type EmotionType = 'joy' | 'sadness' | 'anger' | 'anxiety' | 'peace';
 
 const InitDummyData = () => {
   useEffect(() => {

--- a/frontend/src/app/_components/island/LetterVisualization.tsx
+++ b/frontend/src/app/_components/island/LetterVisualization.tsx
@@ -85,6 +85,9 @@ const LetterVisualization = ({ letterDates, total, category }: Props) => {
           const x = radius * Math.sin(rad);
           const y = -radius * Math.cos(rad) - rowIndex * 50;
 
+          const today = new Date().toISOString().split('T')[0];
+          const isTodayMatch = date === today && status?.type === 'match';
+
           return (
             <div
               key={date}
@@ -97,7 +100,7 @@ const LetterVisualization = ({ letterDates, total, category }: Props) => {
               }}
             >
               <div
-                className="letter-box"
+                className={`letter-box ${isTodayMatch ? 'letter-glow' : ''}`}
                 style={{
                   animation: 'letterFloat 4s ease-in-out infinite',
                 }}

--- a/frontend/src/app/_components/island/LetterVisualization.tsx
+++ b/frontend/src/app/_components/island/LetterVisualization.tsx
@@ -102,7 +102,9 @@ const LetterVisualization = ({ letterDates, total, category }: Props) => {
               <div
                 className={`letter-box ${isTodayMatch ? 'letter-glow' : ''}`}
                 style={{
-                  animation: 'letterFloat 4s ease-in-out infinite',
+                  animation: isTodayMatch
+                  ? 'letterFloat 4s ease-in-out infinite, glowPulse 2.5s ease-in-out infinite'
+                  : 'letterFloat 4s ease-in-out infinite'
                 }}
                 onClick={() => {
                   if (!status || status.type === "none") return; // 클릭 막음

--- a/frontend/src/app/island/[type]/page.tsx
+++ b/frontend/src/app/island/[type]/page.tsx
@@ -168,6 +168,9 @@ const IslandPage = () => {
             src={postoffice}
             onClick={handlePostOfficeClick}
         />
+        <div className='homeButtonText'>
+          홈으로
+        </div>
     </div>
   </div>
   );

--- a/frontend/src/app/island/[type]/page.tsx
+++ b/frontend/src/app/island/[type]/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useParams } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 import Image from 'next/image';
+import { useState, useEffect } from 'react';
+import DatePicker from 'react-datepicker';
 import '@/styles/IslandPage.css';
 import homepageMt from '@/assets/images/homepage-mountain.png';
 import star1 from '@/assets/images/star1.png';
@@ -15,13 +17,12 @@ import relate from '@/assets/images/relate.png';
 import navigateBefore from '@/assets/icons/navigate_before.svg'
 import navigateNext from '@/assets/icons/navigate_next.svg'
 import calendar from '@/assets/icons/calendar.svg'
+
 import { useLetterDateRange } from '@/ui/hooks/useLetterDateRange';
 import { useDateNavigator } from '@/ui/hooks/useDateNavigator';
 import LetterVisualization from '@/app/_components/island/LetterVisualization';
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import DatePicker from 'react-datepicker';
-
+import { useDominantEmotions } from "@/ui/hooks/useDominantEmotions";
+import { EmotionType } from "@/core/entities/emotion"
 
 
 const IslandPage = () => {
@@ -80,6 +81,27 @@ const IslandPage = () => {
       (!isFirstHalf && todayDate >= (isJune2025 ? 17 : 16))
     );
 
+  const dominantEmotions = useDominantEmotions(letterDates, type);
+  const emotionColors: Record<EmotionType, string> = {
+    joy: "#FEE191",
+    peace: "#62B067",
+    sadness: "#4F69D2",
+    anger: "#B25A5A",
+    anxiety: "#AB1EB7",
+  };
+
+  const gradientStyle = {
+    background: dominantEmotions.length
+      ? `radial-gradient(circle,
+          ${emotionColors[dominantEmotions[0]]}DD 0%,    /* 중심: 더 진하게 */
+          ${emotionColors[dominantEmotions[0]]}66 40%,   /* 중간: 살짝 흐리게 */
+          ${emotionColors[dominantEmotions[0]]}33 70%,   /* 경계: 거의 연하게 */
+          ${emotionColors[dominantEmotions[0]]}00 100%)` /* 바깥: 완전 투명 */
+      : undefined,
+  };
+
+
+  console.log("gradientStyle", gradientStyle);
 
   const router = useRouter();
   const handlePostOfficeClick = () => {
@@ -88,6 +110,7 @@ const IslandPage = () => {
 
   return (
     <div className="island-page">
+      <div className="gradient-layer" style={gradientStyle} />
       <div className="background">
         {/* 상단 문구 */}
         <div className = "text-wrapper">
@@ -146,8 +169,8 @@ const IslandPage = () => {
             onClick={handlePostOfficeClick}
         />
     </div>
-</div>
-);
+  </div>
+  );
 };
 
 export default IslandPage;

--- a/frontend/src/styles/IslandPage.css
+++ b/frontend/src/styles/IslandPage.css
@@ -17,6 +17,20 @@
   width: 100%;
 }
 
+.gradient-layer {
+  position: absolute;
+  z-index: 1;
+  top: 60%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 350px;
+  height: 400px;
+  border-radius: 50%;
+  pointer-events: none;
+  opacity: 0.7;
+  filter: blur(30px);
+}
+
 .island-page .text-wrapper {
   color: #ffffff;
   font-family: 'Line Seed Sans KR';
@@ -80,6 +94,7 @@
   width: 100%;
   height: 250px; /* 편지 뜨는 영역 높이 */
   margin-top: 32px;
+  z-index: 3;
 }
 
 .letter-box {

--- a/frontend/src/styles/IslandPage.css
+++ b/frontend/src/styles/IslandPage.css
@@ -114,6 +114,38 @@
   right: '8px';
 }
 
+.letter-glow {
+  animation: glowPulse 1.5s infinite ease-in-out;
+  filter: drop-shadow(0 0 8px rgba(255, 251, 0, 0.8));
+}
+
+@keyframes glowPulse {
+  0% {
+    filter: drop-shadow(0 0 4px rgba(255, 251, 0, 0.2));
+  }
+  50% {
+    filter: drop-shadow(0 0 16px rgba(255, 251, 0, 0.8));
+  }
+  100% {
+    filter: drop-shadow(0 0 4px rgba(255, 251, 0, 0.2));
+  }
+}
+
+@keyframes letterFloatGlow {
+  0% {
+    transform: translateY(0px) rotate(0deg);
+    filter: drop-shadow(0 0 4px rgba(255, 251, 0, 0.2));
+  }
+  50% {
+    transform: translateY(-6px) rotate(0deg);
+    filter: drop-shadow(0 0 16px rgba(255, 251, 0, 1));
+  }
+  100% {
+    transform: translateY(0px) rotate(0deg);
+    filter: drop-shadow(0 0 4px rgba(255, 251, 0, 0.2));
+  }
+}
+
 /* 섬과 각종 요소들 */
 
 .island-page .island {

--- a/frontend/src/styles/IslandPage.css
+++ b/frontend/src/styles/IslandPage.css
@@ -209,6 +209,20 @@
   cursor: pointer;
 }
 
+.homeButtonText {
+  position: absolute;
+  bottom: 13%;
+  left: 80%;
+  transform: translateX(-50%);
+  font-size: 13px;
+  background-color: rgba(255, 255, 255, 0.334);
+  padding: 4px 8px;
+  border-radius: 8px;
+  white-space: nowrap;
+  z-index: 3;
+  pointer-events: none;
+}
+
 /* LetterVisualization에서 쓰이는 팝업 */
 .popup {
   position: fixed;

--- a/frontend/src/ui/hooks/useDominantEmotions.ts
+++ b/frontend/src/ui/hooks/useDominantEmotions.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState, useMemo } from "react";
+import { EmotionStorage } from "@/services/storage/emotionStorage";
+import type { EmotionType } from "@/core/entities/emotion";
+
+export const useDominantEmotions = (dates: string[], category: string) => {
+  const [dominantEmotions, setDominantEmotions] = useState<EmotionType[]>([]);
+  const emotionStorage = useMemo(() => new EmotionStorage(), []);
+
+  useEffect(() => {
+    if (dates.length === 0) return;
+
+    const fetch = async () => {
+      const emotionCount: Record<EmotionType, number> = {
+        joy: 0,
+        peace: 0,
+        sadness: 0,
+        anger: 0,
+        anxiety: 0,
+      };
+
+      for (const date of dates) {
+        const data = await emotionStorage.getByDate(date);
+        if (data?.category === category) {
+          emotionCount[data.emotion]++;
+        }
+      }
+
+      const maxCount = Math.max(...Object.values(emotionCount));
+      const dominant = Object.entries(emotionCount)
+        .filter(([, count]) => count === maxCount && count > 0)
+        .map(([emotion]) => emotion as EmotionType);
+
+      setDominantEmotions(prev =>
+        JSON.stringify(prev) !== JSON.stringify(dominant) ? dominant : prev
+      );
+    };
+
+    fetch();
+  }, [dates, category, emotionStorage]); // ✅ 깔끔한 버전
+
+  return dominantEmotions;
+};


### PR DESCRIPTION
## 작업사항
- [x]  현재 있는 편지 중 가장 많은 비율을 차지하는 emotion(색)으로 섬 뒷배경 칠해지기
- [x]  저장되는 순간 애니메이션 효과 (편지가 날라와서 그 날짜에 위치하도록, 혹은 불가능하다면 오늘의 편지가 반짝이도록)
- [x] 홈으로 돌아가는 섬 고치기 — 메인화면으로 라고 멘트라도 적어놓기 

## 관련 이슈
<!-- 아직 구현되지 않은 기능들, 기능 구현하다 실패한 점, 테스트할 때 유의할 점? -->
[ ] 온기기록할 때 옆으로 치우치는 문제 -> 나왔다 안나왔다 함
[ ] 기록을 불러오는 중 로딩화면 → 배경 있고 새 날아다니는 지빈님 버전으로 업데이트 
[ ] 튜토리얼
[ ] 가능하면 데이터 정리 (후순위)
[ ] 홈버튼 가능하면 디자인 (후순위)

